### PR TITLE
Remove nil check before range iteration

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -39,10 +39,8 @@ func handleCrash(handler func(interface{})) {
 	if r := recover(); r != nil {
 		handler(r)
 
-		if additionalHandlers != nil {
-			for _, fn := range additionalHandlers {
-				fn(r)
-			}
+		for _, fn := range additionalHandlers {
+			fn(r)
 		}
 	}
 }


### PR DESCRIPTION
The range operator handles nil slices as length 0.